### PR TITLE
Fix redis default password and remove debug require

### DIFF
--- a/lib/kitsune/kit/commands/setup_redis_docker.rb
+++ b/lib/kitsune/kit/commands/setup_redis_docker.rb
@@ -4,7 +4,6 @@ require "fileutils"
 require "shellwords"
 require_relative "../defaults"
 require_relative "../options_builder"
-require "pry"
 module Kitsune
   module Kit
     module Commands

--- a/lib/kitsune/kit/defaults.rb
+++ b/lib/kitsune/kit/defaults.rb
@@ -33,7 +33,7 @@ module Kitsune
 
       REDIS = {
         port: "6379",
-        password: "redis:7.2"
+        password: "secret"
       }.freeze
 
       def self.infra

--- a/spec/kitsune/kit/defaults_spec.rb
+++ b/spec/kitsune/kit/defaults_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Kitsune::Kit::Defaults do
       result = described_class.redis
 
       expect(result[:redis_port]).to eq("6379")
-      expect(result[:redis_password]).to eq("redis:7.2")
+      expect(result[:redis_password]).to eq("secret")
     end
 
     it "uses ENV values for redis config" do


### PR DESCRIPTION
## Summary
- remove leftover `require "pry"`
- correct Redis default password to `secret`
- adjust expectations in Defaults spec

## Testing
- `bundle exec rspec` *(fails: bundler command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685489ebe3bc83269375a1c52f9b21b4